### PR TITLE
Added modal link to Covid section

### DIFF
--- a/components/CovidModal.jsx
+++ b/components/CovidModal.jsx
@@ -1,0 +1,100 @@
+import react, { useState } from 'react';
+import styled from 'styled-components';
+import Modal from './Modal';
+import Text from './Typography';
+import Container from './Container';
+
+const Message = styled.div`
+position: relative;
+${Text}{
+  color: var(--color-brand-5);
+
+}
+
+`;
+
+const Root = styled.div`
+${Text}{
+  text-decoration: underline;
+  cursor: pointer;
+  color: #fff;
+}
+`;
+
+const CovidModal = () => {
+  const [modalStatus, setModalStatus] = useState(false);
+  return (
+    <div>
+      <Message>
+        {modalStatus && (
+          <Modal handleModal={() => setModalStatus(false)}>
+            <Container>
+              <Text as="h4">
+                <p>COVID-19 OPERATING POLICIES</p>
+              </Text>
+              <Text>
+                <p>
+                  We’ve been busy taking action to best serve you when the time
+                  was right.
+                </p>
+                <p>
+                  As we re-open, we are following the new COVID-19 Safety
+                  Guidelines:
+                </p>
+                <p>
+                  <li>
+                    Everything the stylist touches will be wiped down after each
+                    client. That includes tools, products, chairs, counters,
+                    etc.
+                  </li>
+                  <li>
+                    Our stylist partners will be wearing face coverings while
+                    inside our shops and serving clients, as well as washing
+                    their hands before and after each service.
+                  </li>
+                </p>
+                <p>
+                  As we re-open, we need your help by following our new COVID
+                  -19 Safety Guidelines:
+                </p>
+                <p>
+                  <li>
+                    Bring a mask. If you do not have a mask we will provide you
+                    with one.
+                  </li>
+                  <li>Wash your hands upon arrival.</li>
+                  <li>
+                    Please come alone. We’re limiting the number of people in a
+                    shop at a time. Please limit the items you bring inside the
+                    salon to just your keys. Please leave any heavy outerwear in
+                    your car if you can. Only beverages secured with lids will
+                    be allowed inside.
+                  </li>
+                  <li>
+                    We encourage cashless tips. You can choose to add the
+                    standard 20% tip to your appointment during the booking
+                    process or find the cash app or PayPal account on your
+                    stylist's workstation mirror.
+                  </li>
+                </p>
+              </Text>
+              <Text as="h5">
+                <p>
+                  We thank you ahead of time for going with the flow. See you
+                  soon!
+                </p>
+              </Text>
+            </Container>
+          </Modal>
+        )}
+      </Message>
+      <Root>
+        <Text as="p" onClick={() => setModalStatus(true)}>
+          Certified in COVID-19 Safety Protocols
+        </Text>
+      </Root>
+    </div>
+  );
+};
+
+export default CovidModal;

--- a/components/Modal.jsx
+++ b/components/Modal.jsx
@@ -1,0 +1,81 @@
+import React, { useState, Children } from 'react';
+import PropTypes from 'prop-types';
+import styled, { css } from 'styled-components';
+
+const StyledModal = styled.div`
+  display: flex;
+  align-items: center;
+  position: relative;
+  visibility: visible;
+  
+.overlay {
+  position: fixed;
+  display: flex;
+  overflow: auto;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  background-color: rgba(0,0,0,0.4);
+  z-index: 999;
+  align-items: center;
+  justify-content: center;
+}
+.content {
+  height: 80%;
+  width: 60%;
+  border-radius: var(--round-radius-2);
+  background-color: var(--color-brand-6);
+  position: absolute;
+  align-center: center;
+  margin: 15% auto;
+  overflow: auto;
+}
+
+span {
+      color: #aaaaaa;
+      position: absolute;
+      font-size: 28px;
+      font-weight: bold;
+      top: 0.5rem;
+      right: 1.5rem;
+      cursor: pointer;
+      :hover,
+      :focus {
+        color: palevioletred;
+        textdecoration: none;
+}`;
+
+const Modal = (props) => {
+  const { handleModal } = props;
+  const { children } = props;
+  const closeicon = () => (
+    <span
+      role="button"
+      tabIndex={0}
+      aria-expanded={handleModal}
+      aria-controls="button"
+      onClick={handleModal}
+      onKeyDown={handleModal}
+    >
+      &times;
+    </span>
+  );
+  return (
+    <StyledModal>
+      <div className="overlay">
+        <div className="content">
+          {closeicon()}
+          {children}
+        </div>
+      </div>
+    </StyledModal>
+  );
+};
+
+Modal.propTypes = {
+  children: PropTypes.func.isRequired,
+  handleModal: PropTypes.func.isRequired,
+};
+
+export default Modal;

--- a/components/SectionCovid.jsx
+++ b/components/SectionCovid.jsx
@@ -6,6 +6,7 @@ import FormulaIcon from '../assets/icons/simple-formula.svg';
 import Pin from './Pin';
 import { Grid, Column } from './Grid';
 import Button from './Button';
+import CovidModal from './CovidModal';
 
 const dropExpose = keyframes`
   0%{
@@ -62,7 +63,7 @@ export default () => (
           </Text>
           <Text>
             <ul>
-              <li>Certified in COVID-19 Safety Protocols</li>
+              <li><CovidModal /></li>
             </ul>
           </Text>
         </Column>


### PR DESCRIPTION
![Covid Modal](https://user-images.githubusercontent.com/62393336/88328614-56470880-ccee-11ea-910a-eda86046ebae.PNG)
![Covid Section](https://user-images.githubusercontent.com/62393336/88328615-56df9f00-ccee-11ea-9067-5c64b4f4bf5b.PNG)

I worked on this modal for about ten days and I know it may not be the best to add this because it won't keep the website simple. I just wanted to challenge myself using event listeners. Please check it out and if this doesn't work, I can design another page of just the COVID info. I have started to work on that in case the modal was decided to be kept and a link for more information could be included.